### PR TITLE
Remove cache step from test action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,15 +27,6 @@ jobs:
     - name: Remove vendor directory
       run: rm -rf vendor
 
-    - name: Cache Composer packages
-      id: composer-cache
-      uses: actions/cache@v2
-      with:
-        path: vendor
-        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-php-
-
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress --no-plugins
 


### PR DESCRIPTION
The cache v2 is no longer supported and we don't really need it.